### PR TITLE
Fix inability to set the SeoPageData annotation's name attribute.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 php:
   - 5.4
+  - hhvm
 env:
   - SYMFONY_VERSION="2.3.*"
   - SYMFONY_VERSION="2.6.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,15 @@ after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --access-token="80b65a15a783f3ca91af2635f701052e94179ebf84aad0a031dcc90dddd30394" --format=php-clover coverage.clover
 matrix:
-  # Build with PHP 5.5 and Symfony LTS
+  # Build with PHP 5.6 and Symfony Next
   include:
-    - php: 5.5
-      env: SYMFONY_VERSION="2.3.*"
     - php: 5.6
-      env: SYMFONY_VERSION="2.7.*@dev"
+      env: SYMFONY_VERSION="dev-master@dev"
 
   # Test the latest PHP and Symfony Next
   allow_failures:
-    - env: SYMFONY_VERSION="2.7.*@dev"
-
+    - env: SYMFONY_VERSION="dev-master@dev"
+    - php: hhvm
 
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - hhvm
 env:
   - SYMFONY_VERSION="2.3.*"
-  - SYMFONY_VERSION="2.6.*"
+  - SYMFONY_VERSION="2.7.*"
   # - SYMFONY_VERSION="3.0.*@dev"
 before_script:
   # - export COMPOSER_PATH=$(which composer)

--- a/Configuration/SeoPageData.php
+++ b/Configuration/SeoPageData.php
@@ -12,7 +12,7 @@
 
 namespace Axstrad\Bundle\SeoBundle\Configuration;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationAnnotation;
+use Axstrad\Bundle\ExtraFrameworkBundle\Configuration\ConfigurationAnnotation;
 
 
 /**

--- a/Tests/Unit/Configuration/SeoPageDataTest.php
+++ b/Tests/Unit/Configuration/SeoPageDataTest.php
@@ -1,0 +1,20 @@
+<?php
+namespace Axstrad\Bundle\SeoBundle\Tests\Unit\Configuration;
+use Axstrad\Bundle\SeoBundle\Configuration\SeoPageData;
+
+/**
+ * @package AxstradSeoBundle
+ * @subpackage Tests
+ */
+class SeoPageDataTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNameIsSetByConstructor()
+    {
+        $fixture = new SeoPageData(array('name' => 'foobar'));
+
+        $this->assertEquals(
+            'foobar',
+            $fixture->name
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 
     "require": {
         "php": "~5.4",
+        "axstrad/extra-framework-bundle": "dev-develop@dev",
         "doctrine/orm": "~2.3",
         "symfony-cmf/seo-bundle": "~1.1",
         "symfony/symfony": "~2.3"


### PR DESCRIPTION
Prior to this commit SeoPageData extend SensioFrameworkExtraBundle's
ConfigurationAnnotation abstract class, which requires setter methods
to set annotation attributes.

This commit introduces AxstradExtraFrameworkBundle which provides a
ConfigurationAnnotation class that uses Symfony's PropertyAccessor to
set the annotation attributes.

Meaning SeoPageData's name attribute will now be set correctly.

This also adds tests for the above.
